### PR TITLE
random grid position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+settings.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 settings.ini
+settings.ini

--- a/Generator.py
+++ b/Generator.py
@@ -12,15 +12,21 @@ gameDir = config.get("gamepath", "GAME_PATH")
 fileName = config.get("filename", "FILE_NAME")
 coordinates = dict()
 
-minX = config.get("mapsize", "MIN_X")
-maxX = config.get("mapsize", "MAX_X")
-minY = config.get("mapsize", "MIN_Y")
-maxY = config.get("mapsize", "MAX_Y")
+# Added padding because the underlying grid is not random - we see particular features coming back
+# unless we drop the town at a random point on the wider grid
+x_padding = random.randrange(-1000, 1000)
+y_padding = random.randrange(-1000, 1000)
+
+minX = x_padding
+maxX = x_padding + int(config.get("mapsize", "X_dimension"))
+minY = y_padding
+maxY = y_padding + int(config.get("mapsize", "Y_dimension"))
 
 minX = int(minX)
 maxX = int(maxX)
 minY = int(minY)
 maxY = int(maxY)
+
 
 cMinX = minX - (minX % 9)
 cMaxX = maxX - (maxX % 9)
@@ -32,8 +38,6 @@ weights = [4, 10, 4, 2, 1, 0.5, 0.3, 0.07, 0.05, 0.03, 0.03]
 adaptedWeights = [0.25, 0.25, 0.4, 0.05, 0.05]
 
 # Add a new corner to output file
-
-
 def addCorner(x, y, ct):
     corner = et.SubElement(corners, "C")
     cX = et.SubElement(corner, "x")
@@ -43,9 +47,8 @@ def addCorner(x, y, ct):
     cY.text = str(y)
     count.text = str(ct)
 
+
 # Add a new voxel to output file
-
-
 def addVoxel(col, ht):
     voxel = et.SubElement(voxels, "V")
     t = et.SubElement(voxel, "t")
@@ -53,9 +56,8 @@ def addVoxel(col, ht):
     t.text = str(col)
     h.text = str(ht)
 
+
 # Get the median of surrounding files, based on input coordinates.
-
-
 def getNearbyMedian(vec):
     heights = []
     for x in range(vec[0] - 9, vec[0] + 10, 9):
@@ -68,9 +70,8 @@ def getNearbyMedian(vec):
     else:
         return int(round(statistics.median(heights)))
 
+
 # Get an adapted height list, based on the input height.
-
-
 def getHeights(ht):
     if ht > 2:
         return [ht - 2, ht - 1, ht, ht + 1, ht + 2]
@@ -99,7 +100,9 @@ voxels = et.SubElement(root, "voxels")
 for x in range(cMinX, cMaxX, 9):
     for y in range(cMinY, cMaxY, 9):
         med = getNearbyMedian([x, y])
-        if med > 0:  # Choose if there actually is a relevant median, if yes create adapted height list and use that for weighted random height.
+        if (
+            med > 0
+        ):  # Choose if there actually is a relevant median, if yes create adapted height list and use that for weighted random height.
             randCount = random.choices(getHeights(med), adaptedWeights)
         else:
             # Choose weighted random height based on the standard list.

--- a/Generator.py
+++ b/Generator.py
@@ -4,38 +4,6 @@ from configparser import ConfigParser
 import os
 import statistics
 
-# Reading in .ini data, as well as creating dict for saving heights at coordinates.
-config = ConfigParser()
-config.read("settings.ini")
-cwd = os.getcwd()
-gameDir = config.get("gamepath", "GAME_PATH")
-fileName = config.get("filename", "FILE_NAME")
-coordinates = dict()
-
-# Added padding because the underlying grid is not random - we see particular features coming back
-# unless we drop the town at a random point on the wider grid
-x_padding = random.randrange(-1000, 1000)
-y_padding = random.randrange(-1000, 1000)
-
-minX = x_padding
-maxX = x_padding + int(config.get("mapsize", "X_dimension"))
-minY = y_padding
-maxY = y_padding + int(config.get("mapsize", "Y_dimension"))
-
-# minX = int(minX)
-# maxX = int(maxX)
-# minY = int(minY)
-# maxY = int(maxY)
-
-
-cMinX = minX - (minX % 9)
-cMaxX = maxX - (maxX % 9)
-cMinY = minY - (minY % 9)
-cMaxY = maxY - (maxY % 9)
-# Standard height list, as well as weights for normal list and generated list based on surroundings.
-heightList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-weights = [4, 10, 4, 2, 1, 0.5, 0.3, 0.07, 0.05, 0.03, 0.03]
-adaptedWeights = [0.25, 0.25, 0.4, 0.05, 0.05]
 
 # Add a new corner to output file
 def addCorner(x, y, ct):
@@ -79,13 +47,56 @@ def getHeights(ht):
         return [0, 1, 2, 3, 4]
 
 
+# Reading in .ini data, as well as creating dict for saving heights at coordinates.
+config = ConfigParser()
+config.read(["settings.ini", "template.ini"])
+cwd = os.getcwd()
+gameDir = config.get("gamepath", "GAME_PATH")
+coordinates = dict()
+
+# Find the highest number savefile
+savefiles = [f for f in os.listdir(gameDir) if os.path.isfile(os.path.join(gameDir, f))]
+save_n = 0
+for s in savefiles:
+    if ".scape" in s:
+        output = s.replace(".scape", "")
+        output = output.replace("Town", "")
+        output = int(output)
+        if output > save_n:
+            save_n = output
+# print(save_n)
+
+fileName = f"Town{save_n+1}.scape"
+
+# Added padding because the underlying grid is not random - we see particular features coming back
+# unless we drop the town at a random point on the wider grid
+x_padding = random.randrange(-1000, 1000)
+y_padding = random.randrange(-1000, 1000)
+
+minX = x_padding
+maxX = x_padding + int(config.get("mapsize", "X_dimension"))
+minY = y_padding
+maxY = y_padding + int(config.get("mapsize", "Y_dimension"))
+
+
+cMinX = minX - (minX % 9)
+cMaxX = maxX - (maxX % 9)
+cMinY = minY - (minY % 9)
+cMaxY = maxY - (maxY % 9)
+
+print(f"({cMinX},{minX})  ({cMaxX},{maxX})  ({cMinY},{minY})  ({cMaxY},{maxX})")
+
+# Standard height list, as well as weights for normal list and generated list based on surroundings.
+heightList = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+weights = [4, 10, 4, 2, 1, 0.5, 0.3, 0.07, 0.05, 0.03, 0.03]
+adaptedWeights = [0.25, 0.25, 0.4, 0.05, 0.05]
+
 # Adding basic data to XML, eg cam positioning.
 root = et.Element("SaveData")
 root.set("xmlns:xsd", "http://www.w3.org/2001/XMLSchema")
 root.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
 
 saveString = et.SubElement(root, "saveString")
-
 cam = et.SubElement(root, "cam")
 camX = et.SubElement(cam, "x")
 camY = et.SubElement(cam, "y")

--- a/Generator.py
+++ b/Generator.py
@@ -22,10 +22,10 @@ maxX = x_padding + int(config.get("mapsize", "X_dimension"))
 minY = y_padding
 maxY = y_padding + int(config.get("mapsize", "Y_dimension"))
 
-minX = int(minX)
-maxX = int(maxX)
-minY = int(minY)
-maxY = int(maxY)
+# minX = int(minX)
+# maxX = int(maxX)
+# minY = int(minY)
+# maxY = int(maxY)
 
 
 cMinX = minX - (minX % 9)

--- a/settings.ini
+++ b/settings.ini
@@ -1,11 +1,11 @@
 [gamepath]
-GAME_PATH = C:\Users\<username>\AppData\LocalLow\Oskar Stalberg\Townscaper 
+GAME_PATH = C:\Users\<user>\AppData\LocalLow\Oskar Stalberg\Townscaper
 
 [filename]
-FILE_NAME = Town42.scape 
+FILE_NAME = Town44.scape
 
-[mapsize] 
-MIN_X = 0
-MAX_X = 45
-MIN_Y = 0
-MAX_Y = 45
+[mapsize]
+X_dimension = 300
+Y_dimension = 300
+
+

--- a/settings.ini
+++ b/settings.ini
@@ -1,2 +1,2 @@
 [gamepath]
-GAME_PATH = C:\Users\wjrol\AppData\LocalLow\Oskar Stalberg\Townscaper
+GAME_PATH = C:\Users\<user>\AppData\LocalLow\Oskar Stalberg\Townscaper

--- a/settings.ini
+++ b/settings.ini
@@ -1,11 +1,2 @@
 [gamepath]
-GAME_PATH = C:\Users\<user>\AppData\LocalLow\Oskar Stalberg\Townscaper
-
-[filename]
-FILE_NAME = Town44.scape
-
-[mapsize]
-X_dimension = 300
-Y_dimension = 300
-
-
+GAME_PATH = C:\Users\wjrol\AppData\LocalLow\Oskar Stalberg\Townscaper

--- a/template.ini
+++ b/template.ini
@@ -1,0 +1,6 @@
+
+[mapsize]
+X_dimension = 300
+Y_dimension = 300
+
+


### PR DESCRIPTION
Added code to start the town at a random position on the underlying grid. This stops us form getting the same recognisable features in the centre of every town generated.

Instead of setting up min/max x and y coordinates in the .ini file, we simplay specify the size of the town and this is added to a random integer in the main generator script.